### PR TITLE
Fix not every java version has separators (ex. Java 14)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>mamo</groupId>
 	<artifactId>VanillaVotifier</artifactId>
-	<version>4.1.2</version>
+	<version>4.1.3</version>
 	<dependencies>
 		<dependency>
 			<groupId>org.jetbrains</groupId>

--- a/src/main/java/mamo/vanillaVotifier/VanillaVotifier.java
+++ b/src/main/java/mamo/vanillaVotifier/VanillaVotifier.java
@@ -69,7 +69,7 @@ public class VanillaVotifier {
 
 	public static void main(@Nullable String[] arguments) {
 		String[] javaVersion = System.getProperty("java.version").split("\\.");
-		if (!(javaVersion.length >= 2 && ((Integer.parseInt(javaVersion[0]) == 1 && Integer.parseInt(javaVersion[1]) >= 6) || Integer.parseInt(javaVersion[0]) >= 2))) {
+		if (!(javaVersion.length >= 2 && ((Integer.parseInt(javaVersion[0]) == 1 && Integer.parseInt(javaVersion[1]) >= 6)) || Integer.parseInt(javaVersion[0]) >= 2)) {
 			System.out.println(("You need at least Java 1.6 to run this program! Current version: " + System.getProperty("java.version") + "."));
 			return;
 		}


### PR DESCRIPTION
Java 14 is not recognized because it doesn't have a separator for the Java version, thus leading to exiting out by not meeting the Java 1.6 requirement.