### PR TITLE
Add timestamps to Logger output

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>mamo</groupId>
 	<artifactId>VanillaVotifier</artifactId>
-	<version>4.1.2</version>
+	<version>4.1.3</version>
 	<dependencies>
 		<dependency>
 			<groupId>org.jetbrains</groupId>

--- a/src/main/java/mamo/vanillaVotifier/Logger.java
+++ b/src/main/java/mamo/vanillaVotifier/Logger.java
@@ -24,19 +24,23 @@ import org.jetbrains.annotations.Nullable;
 import java.io.BufferedWriter;
 import java.io.FileOutputStream;
 import java.io.OutputStreamWriter;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 import java.util.Map.Entry;
 
 public class Logger {
 	@NotNull protected VanillaVotifier votifier;
 	@NotNull protected StringBuffer buffer = new StringBuffer();
 	private BufferedWriter logWriter;
+	private SimpleDateFormat formatter = new SimpleDateFormat("[HH:mm:ss]");
 
 	public Logger(@NotNull VanillaVotifier votifier) {
 		this.votifier = votifier;
 	}
 
 	public void print(@Nullable Object object) {
-		String string = toString(object);
+		String timestamp = formatter.format(new Date());
+		String string = timestamp + " " + toString(object);
 		synchronized (votifier.getWriter()) {
 			try {
 				votifier.getWriter().write(string);
@@ -63,8 +67,7 @@ public class Logger {
 	}
 
 	public void println(@Nullable Object object) {
-		print(toString(object));
-		print(System.getProperty("line.separator"));
+		print(toString(object) + System.getProperty("line.separator"));
 	}
 
 	@NotNull


### PR DESCRIPTION
Add better readability by adding some timestamps in front of the logged messages. It uses the old Date class and SimpleDateFormat and should compile with Java 6.

Make sure to change the version when accepting both pull requests.